### PR TITLE
move recipe logic into provider

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,6 +1,4 @@
-package 'encfs'
-
-directory node[:encfs][:directories][:crypt] do
-  action :create
-  recursive true
-end
+#
+# Cookbook Name:: encfs
+# Recipe:: default
+#


### PR DESCRIPTION
This remove the requirement to put `include_recipe 'encfs'` in your own cookbook. Calling the `encfs` LWRP will configure the package as needed.
